### PR TITLE
Splitb GENCODE bug

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,7 +150,7 @@ dependencies = [
 
 [[package]]
 name = "gtfsort"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "colored 1.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gtfsort"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["alejandrogzi <jose.gonzalesdezavala1@unmsm.edu.pe>"]
 edition = "2021"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 # gtfsort
 An optimized chr/pos/feature GTF 2.5-3 sorter using a lexicographically-based index ordering algorithm written in Rust.
 
-<img width=700 align="center" src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/overview.png">
+<p align="center">
+    <img width=700 align="center" src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/overview.png">
+</p>
 
 While current tools (most of them GFF3-focused) have been recommended for sorting GTF files, none are directed towards chr/pos/feature ordering. This approach ensures custom sorting directionality, which is useful for reducing computation times in tools that work with sorted GTF files. Furthermore, it provides a friendly and organized visualization of gene structures (gene -> transcript -> CDS/exon -> start/stop -> UTR/Sel), allowing users to search for features more efficiently.
 
@@ -125,7 +127,9 @@ In this comparative analysis, gtfsort demonstrated remarkable efficiency, showca
 
 Furthermore, it is noteworthy that the memory allocation required for sorting files remained conservative in three of the tools evaluated: GNU (both single and multi-core), gff3sort, and gtfsort. The memory utilization for the largest file did not exceed 2.3 Gbs, even when handling substantial datasets (up to 1.6 Gbs in size).
 
-<img align=center width=650 src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/benchmark.png">
+<p align="center">
+    <img align=center width=600 src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/benchmark.png">
+</p>
 
 From the suite of tools employed in the preceding step, only three assert to incorporate a feature sorting step [5]: gff3sort, AGAT, and gtfsort. Gff3sort, a Perl-based program tailored for sorting GFF3/GTF files, is adept at generating results compatible with tabix tools [4]. It employs a topological algorithm to sequence features after an initial two-block sorting phase (first by chromosome, then by position). AGAT, an analysis toolkit also scripted in Perl, features a GFF3/GTF sorting tool within the `agat_convert_sp_gxf2gxf.pl` script [3], likewise employing a topological sorting approach.
 
@@ -136,9 +140,9 @@ Although computation time is an important feature, the actual sorting output wou
 - Chromosomal ordering: Only gtfsort and gff3sort presented an intuitive ordering (starting with chromosome 1 and ending with chromosome X). AGAT fails here, locating MT and sex chromosomes at the beginning.
 - Feature ordering: gff3sort (--precise --chr_order natural) completely fails to present an ordered structure of features (something that is quickly perceived by the exon 5 of the first transcript at the beginning of the block). AGAT and gtfsort, conversely, do exhibit an intuitive structure order: gene -> transcript -> features. AGAT presents 2 blocks per transcript, all CDS after all exons with start/stop codons and UTRs at the end. gtfsort, on the other hand, adopted a distinct approach presenting pairs or triplets of features in conjunction with their respective exon numbers, sorted in descending order, even for sequences on negative strands. UTRs were consistently positioned at the conclusion of the sequence, enabling a natural and rapid comprehension of the information associated with a given exon (exon/CDS/start/stop).
 
-
-<img align=center height=750 src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/order.png">
-
+<p align="center">
+    <img align=center height=750 src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/order.png">
+</p>
 
 - All the values presented herein represent the average of five consecutive iterations for each species, encompassing both time and memory usage.
 

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@
 # gtfsort
 An optimized chr/pos/feature GTF 2.5-3 sorter using a lexicographically-based index ordering algorithm written in Rust.
 
-![Overview](https://github.com/alejandrogzi/gtfsort/blob/master/supp/overview.png)
+<img width=700 align="center" src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/overview.png">
 
-While current tools (most of them GFF3-focused) have been recommended for sorting GTF files, none are directed towards chr/pos/feature ordering. This approach ensures custom sorting directionality, which is useful for reducing computation times in tools that work with sorted GTF files. Furthermore, it provides a friendly and organized visualization of gene structures (gene -> transcript -> CDS/exon -> start/stop -> UTR/Sel), allowing users to search for features more efficiently, an aspect not achieved with other tools.
+While current tools (most of them GFF3-focused) have been recommended for sorting GTF files, none are directed towards chr/pos/feature ordering. This approach ensures custom sorting directionality, which is useful for reducing computation times in tools that work with sorted GTF files. Furthermore, it provides a friendly and organized visualization of gene structures (gene -> transcript -> CDS/exon -> start/stop -> UTR/Sel), allowing users to search for features more efficiently.
 
 ## Usage
 ``` rust
@@ -23,6 +23,13 @@ Options:
     --version: print version
 ```
 
+> What's new on v.0.1.1
+>
+> - GENCODE bug (quotation) now has been resolved!
+> - Two more tests have been implemented to check the above improvement
+> - Some typos and syntax have been corrected from all files
+
+
 #### crate: [https://crates.io/crates/gtfsort](https://crates.io/crates/gtfsort)
 
 
@@ -32,7 +39,7 @@ Options:
 
 GTF stands for Gene Transfer Format. The GTF format is a 9-column text format used to describe and represent genomic features. Each of the columns in a GTF file represent useful information [1]:
 
-``` markdown
+``` plaintext
 <seqname>
 
     The <seqname> field contains the name of the sequence which this gene is on.
@@ -85,7 +92,7 @@ to install gtfsort on your system follow this steps:
 
 ## Library
 to include gtfsort as a library and use it within your project follow these steps:
-1. include `gtfsort = 0.1.0` or `gtfsort = "*"` under `[dependencies]` in the `Cargo.toml` file
+1. include `gtfsort = 0.1.1` or `gtfsort = "*"` under `[dependencies]` in the `Cargo.toml` file
 2. the library name is `gtfsort`, to use it just write:
 
     ``` rust
@@ -112,24 +119,32 @@ to build gtfsort from this repo, do:
 
 To assess the efficiency and results of gtfsort, two main benchmarks were conducted. First, I ran gtfsort over the whole Ensembl Animalia GTF3 dataset (110 release; 306 species) [2]. Here, gtfsort demonstrated both of their main attributes: speed and efficiency. This tool is able to sort a 1.9 GB GTF file (*Cyprinus carpio carpio*) in 12 seconds with high accuracy using less than 2.5 GB of RAM. Species of common interest are highlighted. 
 
-Second, gtfsort was compared with currently available related software: GNU v.8.25 (single and multi-core), AGAT (--gff; complete and only-parse phase) [3], gff3sort (--precise --chr_order natural) [4], and rsort (an unpublished previous multi-core Rust implementation using nested structures). To capture the behavior of each one of this tools in a diverse range of fields and uses (bacteria, fungi, insects, mammals, etc), 9 common species were used: *Homo sapiens*, *Mus musculus*, *Canis lupus familiaris*, *Gallus gallus*, *Danio rerio*, *Salmo salar*, *Crocodylus porosus*, *Drosophila melanogaster* and *Saccharomyces cerevisiae*. Here, gtfsort exhibited the second lowest computation time right after GNU (single and multi-core). Is is important to note that GNU does not achieve a stable chr/pos/feature order and even has a problem with sorting commented lines (e.g. lines starting with "#" at the beginning of the file). Remaining tools showed significantly higher times, some even using a parallel approach (rsort ran using 16 cores). On the other hand, the memmory allocated to sort a file was conservative in 3 tools (GNU single and multi-core, gff3sort and gtfsort), reaching 2.3 GB at most for the largest file (1.6 GB). 
+Secondly, I conducted a comparative analysis of the gtfsort utility in relation to several existing software tools: GNU v.8.25 (both in single and multi-core configurations), AGAT (utilizing the --gff flag for both complete and partial parsing phases) [3], gff3sort (with specific options, including --precise and --chr_order natural) [4], and rsort (an unpublished multi-core Rust implementation with nested data structures). This comprehensive evaluation encompassed a diverse array of biological domains, spanning bacteria, fungi, insects, mammals, and more. To ensure a robust assessment, I employed nine common species: *Homo sapiens*, *Mus musculus*, *Canis lupus familiaris*, *Gallus gallus*, *Danio rerio*, *Salmo salar*, *Crocodylus porosus*, *Drosophila melanogaster* and *Saccharomyces cerevisiae*. 
 
-![Benchmark](https://github.com/alejandrogzi/gtfsort/blob/master/supp/benchmark.png)
+In this comparative analysis, gtfsort demonstrated remarkable efficiency, showcasing the second shortest computation time, second only to the GNU software (in both single and multi-core modes). It is worth noting, however, that GNU software fails to consistently maintain a stable chromosome/position/feature order and encounters difficulties when sorting commented lines (e.g., lines commencing with "#" at the beginning of the file). The remaining tools exhibited substantially longer processing times, with some employing parallel processing approaches (for instance, rsort, which utilized 16 cores).
 
-From the pool of tools used in the previous step, only 3 claim to include a feature sorting step [5]: gff3sort, AGAT and gtfsort. gff3sort is a Perl program to sort GFF3/GTF files, producing suitable results for tabix tools [4], it uses topological algorithm to order features after an initial 2-block sorting approach (chromosome and position). AGAT is an analysis toolkit written also in Perl, offering a GFF3/GTF sort tool within `agat_convert_sp_gxf2gxf.pl` script [3], that also uses a topo-sort approach.
+Furthermore, it is noteworthy that the memory allocation required for sorting files remained conservative in three of the tools evaluated: GNU (both single and multi-core), gff3sort, and gtfsort. The memory utilization for the largest file did not exceed 2.3 Gbs, even when handling substantial datasets (up to 1.6 Gbs in size).
 
-The three tools were run with the GRCh38 *Homo sapiens* GTF file from the latest Ensembl release (110) as input. gtfsort was the fastest tool (12.0220 seconds), followed by gff3sort (16.3970 seconds) and AGAT (~900 seconds). The notorious difference with the extensive computation time of AGAT is due to the fact that `agat_convert_sp_gxf2gxf.pl` does not only sort a GTF file but inspects some controversial lines and fixes/adds corrected/missing lines.
+<img align=center width=650 src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/benchmark.png">
 
-Although computation time is an important feature, the actual sorting output would be the key variable to compare. I choose a  random gene (including all its transcripts/features) and tested whether the output ordering is correct or lacks coherence: RSPO4 located at chromosome 20 with two putative transcripts. As a first step, the location of the chromosome was reviewed. Only gtfsort and gff3sort presented an intuitive ordering (starting with chromosome 1 and ending with chromosome X). AGAT fails here, locating MT and sex chromosomes at the beginning. After that, the actual ordering (line-by-line) was extracted from each output file and presented as a directed graph. gff3sort (--precise --chr_order natural) completely fails to present an ordered structure of features (something that is quickly perceived by the exon 5 of the first transcript at the beginning of the block). AGAT and gtfsort, conversely, do exhibit an intuitive structure order: gene -> transcript -> features. AGAT presents 2 blocks per transcript, all CDS after all exons with start/stop codons and UTRs at the end. gtfsort do it different, presenting pairs/triplets of features associated with their exon numbers (sorted in decreasing way even for negative strands) and UTRs at then end, in this way all the information of a given exon (exon/CDS/start/stop) could be quickly perceived in a natural way.
+From the suite of tools employed in the preceding step, only three assert to incorporate a feature sorting step [5]: gff3sort, AGAT, and gtfsort. Gff3sort, a Perl-based program tailored for sorting GFF3/GTF files, is adept at generating results compatible with tabix tools [4]. It employs a topological algorithm to sequence features after an initial two-block sorting phase (first by chromosome, then by position). AGAT, an analysis toolkit also scripted in Perl, features a GFF3/GTF sorting tool within the `agat_convert_sp_gxf2gxf.pl` script [3], likewise employing a topological sorting approach.
 
-![Order](https://github.com/alejandrogzi/gtfsort/blob/master/supp/order.png)
+To assess the performance of these three tools, we subjected them to the GRCh38 *Homo sapiens* GTF file from the latest Ensembl release (110 release). Among the software tested, gtfsort emerged as the fastest, with a processing time of 12.0220 seconds, followed by gff3sort at 16.3970 seconds, and AGAT, which required approximately 900 seconds to complete the sorting operation. The notorious difference with the extensive computation time of AGAT is due to the fact that `agat_convert_sp_gxf2gxf.pl` does not only sort a GTF file but inspects some controversial lines and fixes/adds corrected/missing lines.
+
+Although computation time is an important feature, the actual sorting output would be the key variable to compare. I choose a random gene (including all its transcripts/features) and tested whether the output ordering demonstrated a coherent and accurate layout.
+
+- Chromosomal ordering: Only gtfsort and gff3sort presented an intuitive ordering (starting with chromosome 1 and ending with chromosome X). AGAT fails here, locating MT and sex chromosomes at the beginning.
+- Feature ordering: gff3sort (--precise --chr_order natural) completely fails to present an ordered structure of features (something that is quickly perceived by the exon 5 of the first transcript at the beginning of the block). AGAT and gtfsort, conversely, do exhibit an intuitive structure order: gene -> transcript -> features. AGAT presents 2 blocks per transcript, all CDS after all exons with start/stop codons and UTRs at the end. gtfsort, on the other hand, adopted a distinct approach presenting pairs or triplets of features in conjunction with their respective exon numbers, sorted in descending order, even for sequences on negative strands. UTRs were consistently positioned at the conclusion of the sequence, enabling a natural and rapid comprehension of the information associated with a given exon (exon/CDS/start/stop).
 
 
-*All values presented here are the mean of 5 consecutive iterations for each species (time and memmory usage).
+<img align=center height=750 src="https://github.com/alejandrogzi/gtfsort/blob/master/supp/order.png">
 
-**Due to AGAT-complete and AGAT-parse high computation times, time values for these tools are presented as their decimal part (divided by 10) for visualization purposes.
 
-***All benchmarks were done on a AMD Ryzen 7 5700X @ 3.400GHz 128 GB RAM running on Fedora 37.
+- All the values presented herein represent the average of five consecutive iterations for each species, encompassing both time and memory usage.
+
+- In light of the notably extended computation times associated with AGAT-complete and AGAT-parse, we have expressed the time values for these tools in their decimal form (divided by 10) for enhanced clarity during visualization.
+
+- All benchmark assessments were conducted on an AMD Ryzen 7 5700X with 128 GB of RAM.
 
 ## Limitations
 

--- a/src/gtf.rs
+++ b/src/gtf.rs
@@ -1,7 +1,6 @@
 mod attr;
 pub use attr::*;
 
-
 #[derive(Debug, PartialEq, Eq, Ord, PartialOrd)]
 pub struct Record {
     chrom: String,
@@ -34,11 +33,20 @@ impl Record {
     }
 
     pub fn outer_layer(&self) -> (String, i32, String, String) {
-        (self.chrom.clone(), self.pos, self.gene_id.clone(), self.line.clone())
+        (
+            self.chrom.clone(),
+            self.pos,
+            self.gene_id.clone(),
+            self.line.clone(),
+        )
     }
 
     pub fn gene_to_transcript(&self) -> (String, String, String) {
-        (self.gene_id.clone(), self.transcript_id.clone(), self.line.clone())
+        (
+            self.gene_id.clone(),
+            self.transcript_id.clone(),
+            self.line.clone(),
+        )
     }
 
     pub fn inner_layer(&self) -> (String, String, String) {
@@ -54,15 +62,17 @@ impl Record {
     }
 
     pub fn misc_layer(&self) -> (String, String, String) {
-        (self.transcript_id.clone(), self.feat.clone(), self.line.clone())
+        (
+            self.transcript_id.clone(),
+            self.feat.clone(),
+            self.line.clone(),
+        )
     }
 
     pub fn feature(&self) -> &str {
         &self.feat
     }
-
 }
-
 
 fn splitb(line: String) -> Result<Vec<String>, ParseError> {
     let bytes = line.as_bytes().iter().enumerate();
@@ -81,7 +91,6 @@ fn splitb(line: String) -> Result<Vec<String>, ParseError> {
     entries.push(line[start..].to_string());
     Ok(entries)
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/gtf/attr.rs
+++ b/src/gtf/attr.rs
@@ -1,7 +1,7 @@
+#![allow(dead_code)]
 use std::collections::HashMap;
 
 use thiserror::Error;
-
 
 #[derive(Debug, PartialEq)]
 pub struct Attribute {
@@ -11,10 +11,8 @@ pub struct Attribute {
     exon_id: String,
 }
 
-
 impl Attribute {
     pub fn parse(line: &String) -> Result<Attribute, ParseError> {
-        
         if !line.is_empty() {
             let mut attributes: HashMap<String, String> = HashMap::new();
             let bytes = line.as_bytes().iter().enumerate();
@@ -36,9 +34,18 @@ impl Attribute {
 
             Ok(Attribute {
                 gene_id: gene_id?.to_string(),
-                transcript_id: attributes.get("transcript_id").unwrap_or(&"0".to_string()).to_string(),
-                exon_number: attributes.get("exon_number").unwrap_or(&"z".to_string()).to_string(),
-                exon_id: attributes.get("exon_id").unwrap_or(&"0".to_string()).to_string(),
+                transcript_id: attributes
+                    .get("transcript_id")
+                    .unwrap_or(&"0".to_string())
+                    .to_string(),
+                exon_number: attributes
+                    .get("exon_number")
+                    .unwrap_or(&"z".to_string())
+                    .to_string(),
+                exon_id: attributes
+                    .get("exon_id")
+                    .unwrap_or(&"0".to_string())
+                    .to_string(),
             })
         } else {
             Err(ParseError::Empty)
@@ -62,16 +69,21 @@ impl Attribute {
     }
 }
 
-
 fn get_pair(line: &str) -> (String, String) {
     let mut bytes = line.as_bytes().iter();
-    let i = bytes.position(|b| *b == b' ').ok_or(ParseError::Invalid).unwrap();
+    let i = bytes
+        .position(|b| *b == b' ')
+        .ok_or(ParseError::Invalid)
+        .unwrap();
     let key = &line[..i];
-    let value = &line[i+2..line.len()-1];
-
-    (key.to_string(), value.to_string())
+    if key == "level" || key == "exon_number" {
+        let value = &line[i + 1..line.len()];
+        return (key.to_string(), value.to_string());
+    } else {
+        let value = &line[i + 2..line.len() - 1];
+        return (key.to_string(), value.to_string());
+    }
 }
-
 
 #[derive(Error, Debug, PartialEq)]
 pub enum ParseError {
@@ -81,14 +93,14 @@ pub enum ParseError {
     Invalid,
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn valid_attributes() {
-        let input = "gene_id \"ABC\"; transcript_id \"XYZ\"; exon_number \"1\"; exon_id \"123\";".to_string();
+        let input = "gene_id \"ABC\"; transcript_id \"XYZ\"; exon_number \"1\"; exon_id \"123\";"
+            .to_string();
         let attr = Attribute::parse(&input).unwrap();
 
         assert_eq!(attr.gene_id(), "ABC");
@@ -104,4 +116,105 @@ mod tests {
 
         assert_eq!(result.unwrap_err(), ParseError::Invalid);
     }
+
+    #[test]
+    fn get_gencode_pair_from_gene_line() {
+        let line = "gene_id \"ENSG00000290825.1\"; gene_type \"lncRNA\"; gene_name \"DDX11L2\"; level 2; tag \"overlaps_pseudogene\";".to_string();
+        let mut attributes: HashMap<String, String> = HashMap::new();
+        let bytes = line.as_bytes().iter().enumerate();
+
+        let mut start = 0;
+
+        for (i, byte) in bytes {
+            if *byte == b';' {
+                let word = &line[start..i];
+                if !word.is_empty() {
+                    let (key, value) = get_pair(word);
+                    attributes.insert(key, value);
+                }
+                start = i + 2;
+            }
+        }
+
+        assert_eq!(
+            *attributes.get("gene_id").unwrap(),
+            String::from("ENSG00000290825.1")
+        );
+        assert_eq!(
+            *attributes.get("gene_type").unwrap(),
+            String::from("lncRNA")
+        );
+        assert_eq!(
+            *attributes.get("gene_name").unwrap(),
+            String::from("DDX11L2")
+        );
+        assert_eq!(*attributes.get("level").unwrap(), String::from("2"));
+        assert_eq!(
+            *attributes.get("tag").unwrap(),
+            String::from("overlaps_pseudogene")
+        );
+    }
+}
+
+#[test]
+fn get_gencode_pair_from_exon_line() {
+    let line = "gene_id \"ENSG00000290825.1\"; transcript_id \"ENST00000456328.2\"; gene_type \"lncRNA\"; gene_name \"DDX11L2\"; transcript_type \"lncRNA\"; transcript_name \"DDX11L2-202\"; exon_number 2; exon_id \"ENSE00003582793.1\"; level 2; transcript_support_level \"1\"; tag \"basic\"; tag \"Ensembl_canonical\"; havana_transcript \"OTTHUMT00000362751.1\";".to_string();
+    let mut attributes: HashMap<String, String> = HashMap::new();
+    let bytes = line.as_bytes().iter().enumerate();
+
+    let mut start = 0;
+
+    for (i, byte) in bytes {
+        if *byte == b';' {
+            let word = &line[start..i];
+            if !word.is_empty() {
+                let (key, value) = get_pair(word);
+                attributes.insert(key, value);
+            }
+            start = i + 2;
+        }
+    }
+
+    assert_eq!(
+        *attributes.get("gene_id").unwrap(),
+        String::from("ENSG00000290825.1")
+    );
+    assert_eq!(
+        *attributes.get("transcript_id").unwrap(),
+        String::from("ENST00000456328.2")
+    );
+    assert_eq!(
+        *attributes.get("gene_type").unwrap(),
+        String::from("lncRNA")
+    );
+    assert_eq!(
+        *attributes.get("gene_name").unwrap(),
+        String::from("DDX11L2")
+    );
+    assert_eq!(
+        *attributes.get("transcript_type").unwrap(),
+        String::from("lncRNA")
+    );
+    assert_eq!(
+        *attributes.get("transcript_name").unwrap(),
+        String::from("DDX11L2-202")
+    );
+    assert_eq!(*attributes.get("exon_number").unwrap(), String::from("2"));
+    assert_eq!(
+        *attributes.get("exon_id").unwrap(),
+        String::from("ENSE00003582793.1")
+    );
+    assert_eq!(*attributes.get("level").unwrap(), String::from("2"));
+    assert_eq!(
+        *attributes.get("transcript_support_level").unwrap(),
+        String::from("1")
+    );
+    assert_eq!(
+        *attributes.get("tag").unwrap(),
+        String::from("Ensembl_canonical")
+    );
+    assert_eq!(
+        *attributes.get("havana_transcript").unwrap(),
+        String::from("OTTHUMT00000362751.1")
+    );
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,15 @@
 use gtfsort::gtfsort;
 
-use clap::{Arg, Command, ArgMatches};
+use clap::{Arg, ArgMatches, Command};
 
 use colored::Colorize;
 
-use std::string::String;
 use std::error::Error;
-
+use std::string::String;
 
 fn main() {
     let matches = Command::new("gtfsort")
-        .version("0.1.0")
+        .version("0.1.1")
         .author("Alejandro Gonzales-Irribarren <jose.gonzalesdezavala1@unmsm.edu.pe>")
         .about("An optimized chr/pos/feature GTF2.5-3 sorter using a lexicographic-based index ordering algorithm written in Rust.")
         .arg(Arg::new("i")
@@ -26,13 +25,10 @@ fn main() {
         .get_matches();
 
     if let Some(err) = run(matches).err() {
-        eprintln!("{} {}", 
-                "Error:".bright_red().bold(),
-                err);
+        eprintln!("{} {}", "Error:".bright_red().bold(), err);
         std::process::exit(1);
     }
 }
-
 
 fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
     let i: &String = matches.get_one("i").unwrap();
@@ -40,9 +36,11 @@ fn run(matches: ArgMatches) -> Result<(), Box<dyn Error>> {
 
     let _ = gtfsort(i, o);
 
-    println!("{} {}", 
-    "Success:".bright_green().bold(),
-    "GTF file sorted successfully!");
+    println!(
+        "{} {}",
+        "Success:".bright_green().bold(),
+        "GTF file sorted successfully!"
+    );
 
     Ok(())
 }

--- a/src/ord.rs
+++ b/src/ord.rs
@@ -1,5 +1,5 @@
-use std::cmp::Ordering;
 use natord::compare;
+use std::cmp::Ordering;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd)]
 pub struct Sort {


### PR DESCRIPTION
This PR fixes splitting-by-byte attributes feature to extract feature pairs. Solves cases when unquoted features are present in the 9th column (e.g. level; exon_number), a recurrent problem with GENCODE annotations. Also, fixes some typos and syntax.